### PR TITLE
fix: property dialog shows 1 number extra

### DIFF
--- a/dde-file-manager-lib/io/dfilestatisticsjob.cpp
+++ b/dde-file-manager-lib/io/dfilestatisticsjob.cpp
@@ -258,7 +258,7 @@ int DFileStatisticsJob::directorysCount() const
 {
     Q_D(const DFileStatisticsJob);
 
-    return d->directoryCount.load();
+    return d->directoryCount.load() - 1;
 }
 
 void DFileStatisticsJob::start(const DUrlList &sourceUrls)


### PR DESCRIPTION
It fixes the issue that the property dialog shows 1 number extra